### PR TITLE
Change appcontext to context, as this has been removed in Coq 8.8

### DIFF
--- a/src/pacotacuser.v
+++ b/src/pacotacuser.v
@@ -81,7 +81,7 @@ Tactic Notation "pcofix" ident(CIH) := pcofix CIH with r.
 Ltac pclearbot :=
   let X := fresh "_X" in
   repeat match goal with
-  | [H: appcontext[pacoid] |- _] => red in H; destruct H as [H|X]; [|contradiction X]
+  | [H: context[pacoid] |- _] => red in H; destruct H as [H|X]; [|contradiction X]
   end.
 
 (** ** [pdestruct H] and [pinversion H]


### PR DESCRIPTION
Had problems running this under Coq 8.8-beta1 because appcontext seems to have been removed. It has been deprecated several releases ago, and has the same behaviour as context now.